### PR TITLE
Use Jekyll's default conventions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.3
+  Exclude:
+    - vendor/**/*
+    - jekyll-w2m.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,12 @@
-require 'bundler/gem_tasks'
-require 'rake/testtask'
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'test'
-  t.libs << 'lib'
-  t.test_files = FileList['test/**/*_test.rb']
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
 
-task default: :test
+task :default => :test

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require 'bundler/setup'
-require 'lib'
+require "bundler/setup"
+require "lib"
 
-require 'irb'
+require "irb"
 IRB.start(__FILE__)

--- a/jekyll-w2m.gemspec
+++ b/jekyll-w2m.gemspec
@@ -1,39 +1,42 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "jekyll-w2m/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'jekyll-w2m'
-  spec.version       = '1.0.0'
-  spec.authors       = ['Kacper Duras']
-  spec.email         = ['git@kacperduras.pl']
+  spec.name          = "jekyll-w2m"
+  spec.version       = Jekyll::W2m::VERSION
+  spec.authors       = ["Kacper Duras"]
+  spec.email         = ["git@kacperduras.pl"]
 
-  spec.summary       = 'A Jekyll plugin to liberate content from Microsoft Word documents (powered by word-to-markdown).'
-  spec.homepage      = 'https://github.com/kacperduras/jekyll-w2m'
-  spec.license       = 'MIT'
+  spec.summary       = "A Jekyll plugin to liberate content from Microsoft Word documents (powered by word-to-markdown)."
+  spec.homepage      = "https://github.com/kacperduras/jekyll-w2m"
+  spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
   else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
   end
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = ">= 2.2"
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r!^(test|spec|features)/!)
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r!^exe/!) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
-  spec.add_dependency 'jekyll', '~> 3.7.3'
-  spec.add_dependency 'word-to-markdown', '~> 1.1.7'
+  spec.add_dependency "jekyll", "~> 3.7.3"
+  spec.add_dependency "word-to-markdown", "~> 1.1.7"
 
-  spec.add_development_dependency 'bundler', '~> 1.16.1'
-
-  spec.add_development_dependency 'rake', '~> 12.3'
-  spec.add_development_dependency 'minitest', '~> 5.11.3'
+  spec.add_development_dependency "bundler", "~> 1.16.1"
+  spec.add_development_dependency "minitest", "~> 5.11.3"
+  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rubocop", "~> 0.52.0"
 end

--- a/lib/jekyll-w2m.rb
+++ b/lib/jekyll-w2m.rb
@@ -1,34 +1,31 @@
-require 'jekyll'
-require 'liquid'
+# frozen_string_literal: true
 
-require 'word-to-markdown'
+require "jekyll"
+require "liquid"
+require "word-to-markdown"
 
 module Jekyll
 
   module W2M
 
     class Tag < Liquid::Tag
-
-      def initialize(tag_name, txt, tokens)
+      def initialize(_tag_name, txt, _tokens)
         @context = txt
       end
 
-      def render(context)
+      def render(_context)
         Jekyll::W2M.parse(@context)
       end
-
     end
 
     class << self
-
       def parse(file_path)
         WordToMarkown.new(file_path)
       end
-
     end
 
   end
 
 end
 
-Liquid::Template.register_tag('w2m', Jekyll::W2M::Tag)
+Liquid::Template.register_tag("w2m", Jekyll::W2M::Tag)

--- a/lib/jekyll-w2m/version.rb
+++ b/lib/jekyll-w2m/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module W2m
+    VERSION = "1.0.0"
+  end
+end

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+set -e
+
+script/fmt
+bundle exec rake build

--- a/script/fmt
+++ b/script/fmt
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Lint Ruby according to Jekyll's conventions
+set -e
+
+echo "Rubocop $(bundle exec rubocop --version)"
+bundle exec rubocop -S -D -E $@
+success=$?
+if ((success != 0)); then
+   echo -e "\nTry running \`script/fmt -a\` to automatically fix errors"
+fi
+exit $success

--- a/script/release
+++ b/script/release
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Tag and push a release.
+
+set -e
+
+script/cibuild
+bundle exec rake release


### PR DESCRIPTION
👋 Some conventions we use on Jekyll's plugins:

- Define version in `lib/jekyll-w2m/version.rb`
- Lint with Rubocop
- Run Linting before gem build

### Usage

```sh
➜ script/cibuild
Rubocop 0.52.1
Inspecting 5 files
.....

5 files inspected, no offenses detected
jekyll-w2m 1.0.0 built to pkg/jekyll-w2m-1.0.0.gem.
```